### PR TITLE
Remove call to frozen on version number

### DIFF
--- a/lib/rails_metrics/version.rb
+++ b/lib/rails_metrics/version.rb
@@ -1,3 +1,3 @@
 module RailsMetrics
-  VERSION = "0.1".freeze
+  VERSION = "0.1"
 end


### PR DESCRIPTION
While I was testing on Ruby 1.9.2 I came across a problem with RubyGems trying to modify a frozen version number. Removing the '.freeze' from the version number in rails_metrics/version makes everything happy.
